### PR TITLE
chore: use buf.build remote plugins when possible, expose JS plugins from node_modules PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-generate:
-	export PATH="${PATH}:${HOME}/go/bin";buf generate buf.build/googleapis/googleapis --template ./src/proto/buf.gen.yaml  -o ./src
-	export PATH="${PATH}:${HOME}/go/bin";buf generate --template ./src/proto/buf.gen.yaml ./src/proto -o ./src
+generate: install
+	PATH="$$PATH:$$PWD/node_modules/.bin" buf generate --template ./src/proto/buf.gen.yaml buf.build/googleapis/googleapis -o ./src
+	PATH="$$PATH:$$PWD/node_modules/.bin" buf generate --template ./src/proto/buf.gen.yaml ./src/proto -o ./src
 	sed -i "" -e "s/import\ chat_pb2/from\ \.\ import\ chat_pb2/g" ./src/chat_service_api/grpc/chat_grpc.py
+
+install:
+	pip install .
+	npm ci

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21.6
 require (
 	github.com/edaniels/golog v0.0.0-20230215213219-28954395e8d0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0
-	go.opentelemetry.io/otel/sdk v1.22.0
 	go.viam.com/rdk v0.18.0
 	go.viam.com/utils v0.1.58
 	google.golang.org/genproto/googleapis/api v0.0.0-20240102182953-50ed04b92917

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "google-protobuf": "^3.21.2",
         "grpc-tools": "^1.12.4",
         "protobufjs": "^7.2.6",
-        "protoc-gen-js": "^3.21.2"
+        "protoc-gen-js": "^3.21.2",
+        "ts-protoc-gen": "^0.15.0"
       }
     },
     "node_modules/@bufbuild/buf": {
@@ -2498,6 +2499,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ts-protoc-gen": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.15.0.tgz",
+      "integrity": "sha512-TycnzEyrdVDlATJ3bWFTtra3SCiEP0W0vySXReAuEygXCUr1j2uaVyL0DhzjwuUdQoW5oXPwk6oZWeA0955V+g==",
+      "dev": true,
+      "dependencies": {
+        "google-protobuf": "^3.15.5"
+      },
+      "bin": {
+        "protoc-gen-ts": "bin/protoc-gen-ts"
+      }
+    },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -4575,6 +4588,15 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "ts-protoc-gen": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.15.0.tgz",
+      "integrity": "sha512-TycnzEyrdVDlATJ3bWFTtra3SCiEP0W0vySXReAuEygXCUr1j2uaVyL0DhzjwuUdQoW5oXPwk6oZWeA0955V+g==",
+      "dev": true,
+      "requires": {
+        "google-protobuf": "^3.15.5"
       }
     },
     "unbzip2-stream": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "google-protobuf": "^3.21.2",
     "grpc-tools": "^1.12.4",
     "protobufjs": "^7.2.6",
-    "protoc-gen-js": "^3.21.2"
+    "protoc-gen-js": "^3.21.2",
+    "ts-protoc-gen": "^0.15.0"
   },
   "dependencies": {
     "@viamrobotics/sdk": "^0.11.1-next.0",

--- a/src/chat_go/api.go
+++ b/src/chat_go/api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/edaniels/golog"
-	"go.opentelemetry.io/otel/sdk/resource"
 	"go.viam.com/utils/rpc"
 
 	pb "github.com/viam-labs/chat-service-api/src/chat_go/grpc"

--- a/src/chat_go/grpc/chat.pb.gw.go
+++ b/src/chat_go/grpc/chat.pb.gw.go
@@ -32,7 +32,7 @@ var _ = utilities.NewDoubleArray
 var _ = metadata.Join
 
 var (
-	filter_ChatService_Chat_0 = &utilities.DoubleArray{Encoding: map[string]int{"name": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_ChatService_Chat_0 = &utilities.DoubleArray{Encoding: map[string]int{"name": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_ChatService_Chat_0(ctx context.Context, marshaler runtime.Marshaler, client ChatServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {

--- a/src/chat_service_api_js/grpc/google/api/client_pb.d.ts
+++ b/src/chat_service_api_js/grpc/google/api/client_pb.d.ts
@@ -145,6 +145,9 @@ export class Publishing extends jspb.Message {
   getProtoReferenceDocumentationUri(): string;
   setProtoReferenceDocumentationUri(value: string): void;
 
+  getRestReferenceDocumentationUri(): string;
+  setRestReferenceDocumentationUri(value: string): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): Publishing.AsObject;
   static toObject(includeInstance: boolean, msg: Publishing): Publishing.AsObject;
@@ -167,6 +170,7 @@ export namespace Publishing {
     organization: ClientLibraryOrganizationMap[keyof ClientLibraryOrganizationMap],
     librarySettingsList: Array<ClientLibrarySettings.AsObject>,
     protoReferenceDocumentationUri: string,
+    restReferenceDocumentationUri: string,
   }
 }
 
@@ -452,6 +456,8 @@ export namespace MethodSettings {
   export const defaultHost: jspb.ExtensionFieldInfo<string>;
 
   export const oauthScopes: jspb.ExtensionFieldInfo<string>;
+
+  export const apiVersion: jspb.ExtensionFieldInfo<string>;
 
 export interface ClientLibraryOrganizationMap {
   CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED: 0;

--- a/src/chat_service_api_js/grpc/google/api/client_pb.js
+++ b/src/chat_service_api_js/grpc/google/api/client_pb.js
@@ -42,6 +42,7 @@ goog.exportSymbol('proto.google.api.PhpSettings', null, global);
 goog.exportSymbol('proto.google.api.Publishing', null, global);
 goog.exportSymbol('proto.google.api.PythonSettings', null, global);
 goog.exportSymbol('proto.google.api.RubySettings', null, global);
+goog.exportSymbol('proto.google.api.apiVersion', null, global);
 goog.exportSymbol('proto.google.api.defaultHost', null, global);
 goog.exportSymbol('proto.google.api.methodSignatureList', null, global);
 goog.exportSymbol('proto.google.api.oauthScopes', null, global);
@@ -1154,7 +1155,8 @@ proto.google.api.Publishing.toObject = function(includeInstance, msg) {
     organization: jspb.Message.getFieldWithDefault(msg, 107, 0),
     librarySettingsList: jspb.Message.toObjectList(msg.getLibrarySettingsList(),
     proto.google.api.ClientLibrarySettings.toObject, includeInstance),
-    protoReferenceDocumentationUri: jspb.Message.getFieldWithDefault(msg, 110, "")
+    protoReferenceDocumentationUri: jspb.Message.getFieldWithDefault(msg, 110, ""),
+    restReferenceDocumentationUri: jspb.Message.getFieldWithDefault(msg, 111, "")
   };
 
   if (includeInstance) {
@@ -1232,6 +1234,10 @@ proto.google.api.Publishing.deserializeBinaryFromReader = function(msg, reader) 
     case 110:
       var value = /** @type {string} */ (reader.readString());
       msg.setProtoReferenceDocumentationUri(value);
+      break;
+    case 111:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setRestReferenceDocumentationUri(value);
       break;
     default:
       reader.skipField();
@@ -1331,6 +1337,13 @@ proto.google.api.Publishing.serializeBinaryToWriter = function(message, writer) 
   if (f.length > 0) {
     writer.writeString(
       110,
+      f
+    );
+  }
+  f = message.getRestReferenceDocumentationUri();
+  if (f.length > 0) {
+    writer.writeString(
+      111,
       f
     );
   }
@@ -1573,6 +1586,24 @@ proto.google.api.Publishing.prototype.getProtoReferenceDocumentationUri = functi
  */
 proto.google.api.Publishing.prototype.setProtoReferenceDocumentationUri = function(value) {
   return jspb.Message.setProto3StringField(this, 110, value);
+};
+
+
+/**
+ * optional string rest_reference_documentation_uri = 111;
+ * @return {string}
+ */
+proto.google.api.Publishing.prototype.getRestReferenceDocumentationUri = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 111, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.google.api.Publishing} returns this
+ */
+proto.google.api.Publishing.prototype.setRestReferenceDocumentationUri = function(value) {
+  return jspb.Message.setProto3StringField(this, 111, value);
 };
 
 
@@ -3687,5 +3718,30 @@ google_protobuf_descriptor_pb.ServiceOptions.extensionsBinary[1050] = new jspb.E
 // This registers the extension field with the extended class, so that
 // toObject() will function correctly.
 google_protobuf_descriptor_pb.ServiceOptions.extensions[1050] = proto.google.api.oauthScopes;
+
+
+/**
+ * A tuple of {field number, class constructor} for the extension
+ * field named `apiVersion`.
+ * @type {!jspb.ExtensionFieldInfo<string>}
+ */
+proto.google.api.apiVersion = new jspb.ExtensionFieldInfo(
+    525000001,
+    {apiVersion: 0},
+    null,
+     /** @type {?function((boolean|undefined),!jspb.Message=): !Object} */ (
+         null),
+    0);
+
+google_protobuf_descriptor_pb.ServiceOptions.extensionsBinary[525000001] = new jspb.ExtensionFieldBinaryInfo(
+    proto.google.api.apiVersion,
+    jspb.BinaryReader.prototype.readString,
+    jspb.BinaryWriter.prototype.writeString,
+    undefined,
+    undefined,
+    false);
+// This registers the extension field with the extended class, so that
+// toObject() will function correctly.
+google_protobuf_descriptor_pb.ServiceOptions.extensions[525000001] = proto.google.api.apiVersion;
 
 goog.object.extend(exports, proto.google.api);

--- a/src/proto/buf.gen.yaml
+++ b/src/proto/buf.gen.yaml
@@ -2,35 +2,35 @@
 # from . import chat_pb2
 version: v1
 plugins:
-  - name: python
+  - plugin: buf.build/protocolbuffers/python
     out: chat_service_api/grpc
-  - name: grpclib_python
+  - plugin: grpclib_python
     out: chat_service_api/grpc
-  - name: mypy
+  - plugin: buf.build/community/nipunn1313-mypy
     out: chat_service_api/grpc
-  - name: go
+  - plugin: buf.build/protocolbuffers/go
     out: chat_go/grpc
     opt:
       - paths=source_relative
-  - name: go-grpc
+  - plugin: buf.build/grpc/go
     out: chat_go/grpc
     opt:
       - paths=source_relative
-  - name: grpc-gateway
+  - plugin: buf.build/grpc-ecosystem/gateway
     out: chat_go/grpc
     opt:
       - paths=source_relative
       - generate_unbound_methods=true
-  - name: js
+  - plugin: js
     out: chat_service_api_js/grpc
     opt:
       - import_style=commonjs
-  - name: grpc-web
+  - plugin: grpc-web
     out: chat_service_api_js/grpc
     opt:
       - import_style=commonjs
       - mode=grpcwebtext
-  - name: ts
+  - plugin: ts
     out: chat_service_api_js/grpc
     opt:
       - service=grpc-web


### PR DESCRIPTION
This PR updates the `buf.gen.yaml` file for the `buf` CLI to adopt [remote plugins](https://buf.build/docs/generate/remote-plugins) to remove the need to install many of the protobuf generation plugins locally. This should simplify the setup and discovery of plugins when generating SDK code from the `.proto` API. The only plugins required locally are the Python `grpclib` and JS `protoc-gen-js`, `grpc-web`, `protoc-gen-ts` since they are not in the Buf Schema Registry. 